### PR TITLE
fix trailing/leading divider on empty pageTitle

### DIFF
--- a/page-title.html
+++ b/page-title.html
@@ -91,7 +91,7 @@ automatically, using Polymer bindings. Example:
           pieces.unshift(baseTitle)
         }
       } else if (direction == 'reversed') {
-        if(baseTitle) {
+        if (baseTitle) {
           pieces.push(baseTitle)
         }
       } else {

--- a/page-title.html
+++ b/page-title.html
@@ -80,12 +80,20 @@ automatically, using Polymer bindings. Example:
     ],
 
     _updatePageTitle: function(baseTitle, divider, pageTitle, direction) {
-      var pieces;
+      var pieces = [];
+
+      if (pageTitle) {
+        pieces.push(pageTitle);
+      }
 
       if (direction == 'standard') {
-        pieces = (baseTitle) ? [baseTitle, pageTitle] : [pageTitle];
+        if (baseTitle) {
+          pieces.unshift(baseTitle)
+        }
       } else if (direction == 'reversed') {
-        pieces = (baseTitle) ? [pageTitle, baseTitle] : [pageTitle];
+        if(baseTitle) {
+          pieces.push(baseTitle)
+        }
       } else {
         console.warn("page-title - Did not recognize `direction` property.");
         return;


### PR DESCRIPTION
If your pageTitle is empty when using a baseTitle, there is a trailing (or leading) divider.
This PR only adds parts to the pieces array if they are non-empty, resolving the issue.